### PR TITLE
Update alba maintenance config

### DIFF
--- a/helpers/backend.py
+++ b/helpers/backend.py
@@ -175,6 +175,25 @@ class BackendHelper(CIConstants):
 
         return AlbaBackendList.get_albabackends()
 
+    @classmethod
+    def get_maintenance_config(cls, albabackend_name):
+        """
+        Fetch the maintenance config of an AlbaBackend
+        :param albabackend_name: backend name
+        :type albabackend_name: str
+        :return: dict[str]
+        """
+        return cls.api.get(api='/alba/backends/{0}/get_maintenance_config'.format(BackendHelper.get_alba_backend_guid_by_name(albabackend_name)))
+
+    @classmethod
+    def get_maintenance_metadata(cls):
+        """
+        Fetch the maintenance metadata config
+        :return: dict[str]
+        """
+        return cls.api.get(api='/alba/backends/get_maintenance_metadata')
+
+
     @staticmethod
     def get_preset_by_albabackend(preset_name, albabackend_name):
         """

--- a/setup/backend.py
+++ b/setup/backend.py
@@ -179,6 +179,32 @@ class BackendSetup(CIConstants):
             return True
 
     @classmethod
+    def update_maintenance_config(cls, albabackend_name, *args, **kwargs):
+        """
+        Update the maintenance config of an AlbaBackend
+        :param albabackend_name: Name of the AlbaBackend
+        :type albabackend_name: str
+        """
+        alba_backend_guid = BackendHelper.get_alba_backend_guid_by_name(albabackend_name)
+        maintenance_metadata = BackendHelper.get_maintenance_metadata()
+        maintenance_config = {}
+
+        for key, value in kwargs.iteritems():
+            if maintenance_metadata['edit_metadata'].get(key):
+                # key_type = maintenance_metadata['edit_metadata'].get(key)
+                if isinstance(value, int):
+                    maintenance_config[key] = value
+                else:
+                    raise AttributeError("Key `{0}` cannot be set. Key type is not correct: Current type `{1}` should be `{2}`".format(key, type(value), type(int)))
+            else:
+                raise AttributeError("Key `{0}` cannot be set. Only following keys are allowed: `{1}`".format(key, ', '.join(maintenance_metadata['edit_metadata'].keys())))
+
+        cls.api.post(
+            api='/alba/backends/{0}/set_maintenance_config'.format(alba_backend_guid),
+            data={'maintenance_config': maintenance_config}
+        )
+
+    @classmethod
     @required_backend
     @filter_osds
     def add_asds(cls, target, disks, albabackend_name, claim_retries=MAX_CLAIM_RETRIES, *args, **kwargs):

--- a/setup/backend.py
+++ b/setup/backend.py
@@ -35,6 +35,8 @@ class BackendSetup(CIConstants):
     MAX_BACKEND_TRIES = 20
     MAX_CLAIM_RETRIES = 5
 
+    TYPE_MAPPING = {'integer': int}
+
     def __init__(self):
         pass
 
@@ -191,11 +193,11 @@ class BackendSetup(CIConstants):
 
         for key, value in kwargs.iteritems():
             if maintenance_metadata['edit_metadata'].get(key):
-                # key_type = maintenance_metadata['edit_metadata'].get(key)
-                if isinstance(value, int):
+                key_type = cls.TYPE_MAPPING[maintenance_metadata['edit_metadata'].get(key)]
+                if isinstance(value, key_type):
                     maintenance_config[key] = value
                 else:
-                    raise AttributeError("Key `{0}` cannot be set. Key type is not correct: Current type `{1}` should be `{2}`".format(key, type(value), type(int)))
+                    raise AttributeError("Key `{0}` cannot be set. Key type is not correct: Current type `{1}` should be `{2}`".format(key, type(value), key_type))
             else:
                 raise AttributeError("Key `{0}` cannot be set. Only following keys are allowed: `{1}`".format(key, ', '.join(maintenance_metadata['edit_metadata'].keys())))
 


### PR DESCRIPTION
Give the option to update the maintenance config of a backend.
This can be used for qa to set the auto_cleanup_deleted_namespaces to 0 (delete immediately)